### PR TITLE
Docker setup with single /api/hello route

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+PORT=YOUR_PORT

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,17 @@
+module.exports = {
+  root: true,
+  env: {
+    node: true
+  },
+  extends: [
+    "eslint:recommended",
+    "plugin:prettier/recommended"
+  ],
+  rules: {
+    "no-console": process.env.NODE_ENV === "production" ? "error" : "off",
+    "no-debugger": process.env.NODE_ENV === "production" ? "error" : "off"
+  },
+  parserOptions: {
+    parser: "babel-eslint"
+  }
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,21 @@
 
+node_modules
+.DS_Store
+
+# Editor directories and files
+.idea
+.vscode
+*.suo
+*.ntvs*
+*.njsproj
+
+# Log files
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+yarn.lock
+package-lock.json
+
+# Environment files
+.env
+.env.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:12.2.0
+
+WORKDIR /authms
+COPY package.json /authms/
+RUN npm install
+
+COPY ./ /authms
+
+RUN npm run build
+
+CMD ["npm", "run", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,4 +11,4 @@ services:
       - JWT_SECRET=$JWT_SECRET
       - DB_URL=$DB_URL
     ports:
-      - 95:3050
+      - 81:3050

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,4 +11,4 @@ services:
       - JWT_SECRET=$JWT_SECRET
       - DB_URL=$DB_URL
     ports:
-      - 80:3050
+      - 95:3050

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3"
+services:
+  authms:
+    container_name: authms
+    build:
+      context: .
+    env_file: .env
+    environment:
+      - PORT=$PORT
+      - KEY=$KEY
+      - JWT_SECRET=$JWT_SECRET
+      - DB_URL=$DB_URL
+    ports:
+      - 80:3050

--- a/package.json
+++ b/package.json
@@ -1,0 +1,40 @@
+{
+	"name": "auth-ms",
+	"version": "1.0.0",
+	"description": "A dockerized micro-service for authentication",
+	"main": "index.js",
+	"scripts": {
+		"build": "babel server --out-dir build",
+		"start": "set NODE_ENV=production && node ./build/index.js",
+		"dev-start": "set NODE_ENV=development && nodemon --exec babel-node server/index.js"
+	},
+	"keywords": [
+		"Docker",
+		"Microservice",
+		"Node",
+		"Authentication",
+		"MS"
+	],
+	"author": "team-avengers",
+	"license": "ISC",
+	"dependencies": {
+		"bcryptjs": "^2.4.3",
+		"cors": "^2.8.5",
+		"dotenv": "^8.2.0",
+		"express": "^4.17.1",
+		"mongoose": "^5.9.18",
+		"passport": "^0.4.1",
+		"passport-local": "^1.0.0"
+	},
+	"devDependencies": {
+		"@babel/cli": "^7.0.0-rc.1",
+		"@babel/core": "^7.0.0-rc.1",
+		"@babel/node": "^7.0.0-rc.1",
+		"babel-eslint": "^10.0.1",
+		"@babel/preset-env": "^7.0.0-rc.1",
+		"eslint": "^5.16.0",
+		"@babel/plugin-proposal-private-methods": "^7.6.0",
+		"@babel/plugin-syntax-dynamic-import": "^7.2.0",
+		"babel-plugin-import": "^1.13.0"
+	}
+}

--- a/server/.babelrc
+++ b/server/.babelrc
@@ -1,0 +1,16 @@
+{
+	"presets": [
+		[
+			"@babel/preset-env",
+			{
+				"targets": {
+					"node": "10"
+				}
+			}
+		]
+	],
+	"plugins": [
+		"@babel/plugin-syntax-dynamic-import",
+		"@babel/plugin-proposal-private-methods"
+	]
+}

--- a/server/app.js
+++ b/server/app.js
@@ -1,0 +1,14 @@
+import express from "express";
+import cors from "cors";
+import routes from "./routes";
+const app = express();
+
+app.use(cors());
+app.use(express.json());
+
+app.use("/api", routes);
+
+
+module.exports = app;
+
+

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,10 @@
+import http from "http";
+import app from "./app";
+import dotenv from "dotenv";
+dotenv.config();
+
+const server = http.createServer(app);
+
+server.listen(process.env.PORT || 3050, () => {
+  console.log(`Server Listening on port ${process.env.PORT}`);
+});

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,0 +1,12 @@
+import { Router } from "express";
+
+const router = Router();
+
+router.get("/hello", function (req, res) {
+    return res.status(200).send({
+          success: true,
+          message: "Hello world"
+        });
+} );
+
+export default router;


### PR DESCRIPTION
### What does this PR do?
- This PR setup the project with babel and nodemon for development
- It orchestrates the project with Docker and docker-compose for production deployment

### How should this be manually tested?
- for docker test, ensure you have Docker engine installed on your machine, in the root of the folder run `docker-compose up` once setup is complete point postman or  api testing tool to **http://localhost:81/api/hello**

- for development test run `npm install` to install dependencies and `npm run dev-start` to start development. 

**please note that nodemon is required for development for hot update**

### Screenshots
![image](https://user-images.githubusercontent.com/7990807/84025126-f0dbca00-a982-11ea-8006-7e6c12f9d834.png)

![image](https://user-images.githubusercontent.com/7990807/84026196-cbe85680-a984-11ea-8356-b9ada9c70c7b.png)


