### PR TITLE
Implemented Login and Register feature

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,0 @@
-PORT=YOUR_PORT

--- a/auth/app.js
+++ b/auth/app.js
@@ -1,10 +1,49 @@
 import express from "express";
 import cors from "cors";
 import routes from "./routes";
+import passport from "passport";
+import session from "express-session";
+import mongoose from 'mongoose';
+import connectMongo from "connect-mongo";
+import bodyParser from "body-parser";
+import dotenv from "dotenv";
+
+
+dotenv.config()
 const app = express();
 
+const MongoStore = connectMongo(session);
+
+mongoose.connect(process.env.DB, 
+    {
+        useNewUrlParser: true,
+        useUnifiedTopology: true, 
+        useCreateIndex: true
+    }, (err, db) => {
+        if(!err) {
+            console.log('DB Connected');
+        }
+    }
+)
+
+var sess = {
+    secret: process.env.SESSION_SECRET,
+    store: new MongoStore({mongooseConnection: mongoose.connection}),
+    resave: false,
+    saveUninitialized: true,
+    cookie: {
+
+    },
+}
+
+app.use(session(sess));
 app.use(cors());
 app.use(express.json());
+app.use(bodyParser.json());
+app.use(bodyParser.urlencoded({extended: false}));  
+
+app.use(passport.initialize());
+app.use(passport.session());
 
 app.use("/api", routes);
 

--- a/auth/app.js
+++ b/auth/app.js
@@ -32,9 +32,15 @@ var sess = {
     resave: false,
     saveUninitialized: true,
     cookie: {
-
+        path: '/api',
+        maxAge: 1000 * 60 * 60 * 24 * 15
     },
 }
+
+// if(app.get('env') === 'production') {
+//     app.set('trust proxy', 1)
+//     sess.cookie.secure = true
+// }
 
 app.use(session(sess));
 app.use(cors());

--- a/auth/auth.js
+++ b/auth/auth.js
@@ -31,6 +31,7 @@ passport.serializeUser((user, done) => {
 
 passport.deserializeUser((id, done) => {
     //find user using id from session store
+    console.log('inside ds cb')
     User.findById(id, (err, user) => {
         if(err) return done(err);
         done(null, user);

--- a/auth/auth.js
+++ b/auth/auth.js
@@ -1,0 +1,40 @@
+import passport from 'passport';
+import LocalStrategy from 'passport-local';
+import bcrypt from 'bcrypt';
+import User from './models/User';
+import { Model } from 'mongoose';
+
+
+// LocalStrategy called by passport.authenticate('local') in routes index
+
+passport.use(new LocalStrategy(
+    {usernameField: 'email'},
+    (email, password, done) => {
+
+        User.findOne({email: email}, (err, user) => {
+            if(err) return done(err);
+            if(!user) {return done(null, false);}
+            if(!bcrypt.compareSync(password, user.password)) {
+                return done(null, false);
+            }
+            return done(null, user);
+        })
+    }
+))
+
+// Serialize user to session store on first login
+passport.serializeUser((user, done) => {
+    done(null, user._id);
+});
+
+// deserialize user from session store
+
+passport.deserializeUser((id, done) => {
+    //find user using id from session store
+    User.findById(id, (err, user) => {
+        if(err) return done(err);
+        done(null, user);
+    });
+})
+
+module.exports = passport;

--- a/auth/auth_controllers/authcontroller.js
+++ b/auth/auth_controllers/authcontroller.js
@@ -1,23 +1,60 @@
 import passport from 'passport';
+import EmailValidator from 'email-validator';
+import dns from 'dns';
 
 class AuthController {
 
     static signIn(req, res, next) {
         passport.authenticate('local', (err, user, info) => {
     
-          if(!user) return res.json({result: 'error', status: 'No user found'})
           req.login(user, (err) => {
-            
+            console.log('logging in user')
             if(err) {
               //something went wrong
               res.json({result: 'error', status: 'Unable to log in'})
             } else {
               //successful login
-              res.json({result: 'success', status: 'Authenticated and logged in.'});
+              res.json({
+                result: 'success', 
+                status: 'Authenticated and logged in.',
+                userDetails: {
+                  email: req.user.email,
+                  first_name: req.user.first_name,
+                  last_name: req.user.last_name,
+                  gender: req.user.gender
+                }
+              });
             }
     
           })
         })(req, res, next);
+      }
+
+      static authRequired(req, res, next) {
+        if(req.isAuthenticated()) {
+          return next();
+        }
+        return res.json({result: 'error', status: 'Must be logged in first'})
+      }
+
+      static checkEmailValidity(req, res, next) {
+        const email = req.body.email;
+
+
+
+        if(EmailValidator.validate(email)) {
+          let hostname = email.substring(email.indexOf('@') + 1);
+          
+          dns.lookup(hostname, (err, address, family) => {
+            if(address && family) {
+              console.log(address, family)
+              return next();
+            }
+            return res.json({result: 'error', status: 'Invalid hostname for email'});
+          })
+        } else {
+          res.json({esult: 'error', status: 'Invalid email address'})
+        }
       }
 }
 

--- a/auth/auth_controllers/authcontroller.js
+++ b/auth/auth_controllers/authcontroller.js
@@ -1,0 +1,24 @@
+import passport from 'passport';
+
+class AuthController {
+
+    static signIn(req, res, next) {
+        passport.authenticate('local', (err, user, info) => {
+    
+          if(!user) return res.json({result: 'error', status: 'No user found'})
+          req.login(user, (err) => {
+            
+            if(err) {
+              //something went wrong
+              res.json({result: 'error', status: 'Unable to log in'})
+            } else {
+              //successful login
+              res.json({result: 'success', status: 'Authenticated and logged in.'});
+            }
+    
+          })
+        })(req, res, next);
+      }
+}
+
+export default AuthController;

--- a/auth/index.js
+++ b/auth/index.js
@@ -1,7 +1,9 @@
 import http from "http";
 import app from "./app";
 import dotenv from "dotenv";
+
 dotenv.config();
+
 
 const server = http.createServer(app);
 

--- a/auth/models/User.js
+++ b/auth/models/User.js
@@ -18,6 +18,7 @@ var userSchema = new Schema({
     gender: {
         type: String,
         required: true,
+        enum: ['male', 'female', 'none']
     },
     password: {
         type: String,

--- a/auth/models/User.js
+++ b/auth/models/User.js
@@ -1,0 +1,28 @@
+import mongoose from 'mongoose';
+
+const Schema = mongoose.Schema;
+
+var userSchema = new Schema({
+    email: {
+        type: String,
+        required: true
+    },
+    first_name: {
+        type: String,
+        required: true,
+    },
+    last_name: {
+        type: String,
+        required: true,
+    },
+    gender: {
+        type: String,
+        required: true,
+    },
+    password: {
+        type: String,
+        required: true
+    }
+});
+
+module.exports = mongoose.model('User', userSchema);

--- a/auth/routes/index.js
+++ b/auth/routes/index.js
@@ -1,12 +1,61 @@
 import { Router } from "express";
+import auth from '../auth';
+import passport from "passport";
+import User from '../models/User'
+import AuthController from '../auth_controllers/authcontroller';
+import bcrypt from 'bcrypt';
 
 const router = Router();
 
 router.get("/hello", function (req, res) {
-    return res.status(200).send({
+    return res.status(200).json({
           success: true,
-          message: "Hello world"
+          message: "Hello world",
+          id: req.sessionID,
+          session: req.session.passport,
         });
-} );
+});
+
+router.route("/login")
+  .post(AuthController.signIn);
+
+router.route('/register')
+  .post((req, res, next) => {
+    const {email, first_name, last_name, gender, password} = req.body;
+
+    User.findOne({email: email}, (err, user) => {
+      if(err) return next(err);
+      if(user) {
+        return next(null, false);
+      } else {
+
+        try {
+          let newUser = new User({
+            email: email, 
+            first_name: first_name,
+            last_name: last_name,
+            gender: gender,
+            password: bcrypt.hashSync(password, 12)
+          });
+
+          newUser.save((err, new_user) => {
+            if(err) return next(err);
+            console.log('created user');
+            return next(null, new_user);
+          });
+
+        } catch(err) {
+          res.json({result: 'error', status: 'Fields not filled correctly'});
+        }
+
+      }
+    })
+  }, AuthController.signIn);
+
+  // router.get('/rem', (req, res) => {
+  //   User.remove({}, (err, data) => {
+  //     res.send(data)
+  //   })
+  // })
 
 export default router;

--- a/auth/routes/index.js
+++ b/auth/routes/index.js
@@ -71,17 +71,4 @@ router.route('/reset-password')
   })
 
 
-
-  router.get('/rem', (req, res) => {
-    User.remove({}, (err, data) => {
-      res.send(data)
-    })
-  })
-
-  router.get('/all', (req, res) => {
-    User.find({}, (err, data) => {
-      res.send(data)
-    })
-  })
-
 export default router;

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 		"connect-mongo": "^3.2.0",
 		"cors": "^2.8.5",
 		"dotenv": "^8.2.0",
+		"email-validator": "^2.0.4",
 		"express": "^4.17.1",
 		"express-session": "^1.17.1",
 		"mongoose": "^5.9.18",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"build": "babel server --out-dir build",
 		"start": "set NODE_ENV=production && node ./build/index.js",
-		"dev-start": "set NODE_ENV=development && nodemon --exec babel-node server/index.js"
+		"dev-start": "set NODE_ENV=development && nodemon --exec babel-node auth/index.js"
 	},
 	"keywords": [
 		"Docker",
@@ -18,10 +18,14 @@
 	"author": "team-avengers",
 	"license": "ISC",
 	"dependencies": {
+		"bcrypt": "^5.0.0",
 		"bcryptjs": "^2.4.3",
+		"body-parser": "^1.19.0",
+		"connect-mongo": "^3.2.0",
 		"cors": "^2.8.5",
 		"dotenv": "^8.2.0",
 		"express": "^4.17.1",
+		"express-session": "^1.17.1",
 		"mongoose": "^5.9.18",
 		"passport": "^0.4.1",
 		"passport-local": "^1.0.0"
@@ -30,11 +34,12 @@
 		"@babel/cli": "^7.0.0-rc.1",
 		"@babel/core": "^7.0.0-rc.1",
 		"@babel/node": "^7.0.0-rc.1",
-		"babel-eslint": "^10.0.1",
-		"@babel/preset-env": "^7.0.0-rc.1",
-		"eslint": "^5.16.0",
 		"@babel/plugin-proposal-private-methods": "^7.6.0",
 		"@babel/plugin-syntax-dynamic-import": "^7.2.0",
-		"babel-plugin-import": "^1.13.0"
+		"@babel/preset-env": "^7.0.0-rc.1",
+		"babel-eslint": "^10.0.1",
+		"babel-plugin-import": "^1.13.0",
+		"eslint": "^5.16.0",
+		"session-file-store": "^1.4.0"
 	}
 }


### PR DESCRIPTION
Implemented register feat at API endpoint /api/register, also checks for email validity first.
![Screenshot from 2020-06-09 05-49-56](https://user-images.githubusercontent.com/38760034/84111189-5335d880-aa1e-11ea-8532-0a22633ae173.png)


Implemented login feat at API endpoint /api/login
![Screenshot from 2020-06-09 05-53-40](https://user-images.githubusercontent.com/38760034/84111221-62b52180-aa1e-11ea-8621-678e3890673f.png)


Implemented reset password feature at API endpoint /api/reset-password
![Screenshot from 2020-06-09 05-54-29](https://user-images.githubusercontent.com/38760034/84111244-6c3e8980-aa1e-11ea-96de-629ff4bc3ddd.png)

`express-session` was also used for sessions. Sessions are stored in mongodb with connect-mongo. 
Cookie maxAge set to 15 days ( Users can stay logged in for 15 days.)
